### PR TITLE
Add secrets support to the options

### DIFF
--- a/container.nix
+++ b/container.nix
@@ -319,6 +319,14 @@ let
       property = "SeccompProfile";
     };
 
+    secrets = quadletUtils.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "secret[,opt=opt …]" ];
+      description = "--secret";
+      property = "Secret";
+    };
+
     securityLabelDisable = quadletUtils.mkOption {
       type = types.nullOr types.bool;
       default = null;


### PR DESCRIPTION
I had a container that needed secrets to function, so this just simply adds secrets support to the options.

I've got it [working here on my own setup](https://forge.light.kow.is/kowis-projects/nixos-configuration/src/branch/main/hosts/paperless/default.nix#L95) 