### PR TITLE
Allow specifying image from a package ie pkgs.dockerTools.buildImage

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -18,7 +18,7 @@ let
   # TODO: replace with lib.mergeAttrsList once stable.
   mergeAttrsList = foldl mergeAttrs { };
 
-  containerOpts = types.submodule (import ./container.nix { inherit quadletUtils; });
+  containerOpts = types.submodule (import ./container.nix { inherit quadletUtils pkgs; });
   networkOpts = types.submodule (import ./network.nix { inherit quadletUtils pkgs; });
   podOpts = types.submodule (import ./pod.nix { inherit quadletUtils; });
 in


### PR DESCRIPTION
I needed to use an image I had built with `pkgs.dockerTools.buildImage` so I cribbed the oci-containers module for how to do it. Some of it is directly copy pasted, if anyone could advise as to whether i need to add attribution that would be appreciated. Adding in the ability to use a streaming image file is on my mind, since it would speed up building images immensely