### PR TITLE
feat: use system Podman package

### DIFF
--- a/network.nix
+++ b/network.nix
@@ -1,6 +1,5 @@
 {
   quadletUtils,
-  pkgs,
 }:
 {
   config,
@@ -9,7 +8,7 @@
   ...
 }:
 let
-  inherit (lib) types mkOption;
+  inherit (lib) types mkOption getExe;
 
   networkOpts = {
     disableDns = quadletUtils.mkOption {
@@ -156,7 +155,7 @@ in
         };
         Network = quadletUtils.configToProperties networkConfig networkOpts;
         Service = {
-          ExecStop = "${pkgs.podman}/bin/podman network rm ${networkName}";
+          ExecStop = "${getExe quadletUtils.podmanPackage} network rm ${networkName}";
         } // config.serviceConfig;
       };
     in

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -16,10 +16,11 @@ let
         inherit lib config pkgs;
       }).systemdUtils.lib;
     isUserSystemd = false;
+    podmanPackage = config.virtualisation.podman.package;
   };
 
   containerOpts = types.submodule (import ./container.nix { inherit quadletUtils; });
-  networkOpts = types.submodule (import ./network.nix { inherit quadletUtils pkgs; });
+  networkOpts = types.submodule (import ./network.nix { inherit quadletUtils; });
   podOpts = types.submodule (import ./pod.nix { inherit quadletUtils; });
 in
 {
@@ -67,7 +68,7 @@ in
         # Ensure podman-user-generator is available for systemd user services.
         {
           "systemd/user-generators/podman-user-generator" = {
-            source = "${pkgs.podman}/lib/systemd/user-generators/podman-user-generator";
+            source = "${quadletUtils.podmanPackage}/lib/systemd/user-generators/podman-user-generator";
           };
         }
         // mergeAttrsList (

--- a/utils.nix
+++ b/utils.nix
@@ -1,4 +1,4 @@
-{ lib, systemdLib, isUserSystemd }:
+{ lib, systemdLib, isUserSystemd, podmanPackage }:
 
 let
   attrsToList =
@@ -31,4 +31,6 @@ in
   # systemd recommends multi-user.target over default.target.
   # https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#default.target
   defaultTarget = if isUserSystemd then "default.target" else "multi-user.target";
+
+  inherit podmanPackage;
 }


### PR DESCRIPTION
Use case: I tun stable NixOS, but I use `podman` from the unstable channel. The current config results in two versions of `podman` used: quadlets are generated with 5.2.3 (from stable), but containers are running in 5.3.0 (from unstable)