### PR TITLE
fix: container.notify type

### DIFF
--- a/container.nix
+++ b/container.nix
@@ -310,7 +310,7 @@ let
     };
 
     notify = quadletUtils.mkOption {
-      type = types.nullOr types.bool;
+      type = types.nullOr (types.enum [ "true" "false" "healthy" ]);
       default = null;
       description = "--sdnotify container";
       property = "Notify";

--- a/container.nix
+++ b/container.nix
@@ -310,7 +310,7 @@ let
     };
 
     notify = quadletUtils.mkOption {
-      type = types.nullOr (types.enum [ "true" "false" "healthy" ]);
+      type = types.enum [ null true false "healthy" ];
       default = null;
       description = "--sdnotify container";
       property = "Notify";


### PR DESCRIPTION
`Notify` field also accepts the value `healthy`:

>In addition, setting Notify to healthy will postpone startup notifications until such time as the container is marked healthy, as determined by Podman healthchecks. Note that this requires setting up a container healthcheck, see the HealthCmd option for more.

From https://docs.podman.io/en/v5.3.1/markdown/podman-systemd.unit.5.html#notify-defaults-to-false
Also in code: https://github.com/containers/podman/blob/8ff491b0d9109a293847bb6a612fa195094fd6ca/pkg/systemd/quadlet/quadlet.go#L679-L691