### PR TITLE
feat: Improve serviceConfig & unitConfig mergeability

### DIFF
--- a/container.nix
+++ b/container.nix
@@ -506,11 +506,11 @@ in
     };
     containerConfig = containerOpts;
     unitConfig = mkOption {
-      type = types.attrs;
+      type = types.attrsOf quadletUtils.unitOption;
       default = { };
     };
     serviceConfig = mkOption {
-      type = types.attrs;
+      type = types.attrsOf quadletUtils.unitOption;
       default = serviceConfigDefault;
     };
 

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -12,7 +12,7 @@ let
   cfg = config.virtualisation.quadlet;
   quadletUtils = import ./utils.nix {
     inherit lib;
-    systemdLib = (libUtils { inherit lib config pkgs; }).systemdUtils.lib;
+    systemdUtils = (libUtils { inherit lib config pkgs; }).systemdUtils;
     isUserSystemd = true;
     podmanPackage = osConfig.virtualisation.podman.package or pkgs.podman;
   };

--- a/network.nix
+++ b/network.nix
@@ -127,11 +127,11 @@ in
     };
     networkConfig = networkOpts;
     unitConfig = mkOption {
-      type = types.attrs;
+      type = types.attrsOf quadletUtils.unitOption;
       default = { };
     };
     serviceConfig = mkOption {
-      type = types.attrs;
+      type = types.attrsOf quadletUtils.unitOption;
       default = { };
     };
 

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -11,10 +11,7 @@ let
   cfg = config.virtualisation.quadlet;
   quadletUtils = import ./utils.nix {
     inherit lib;
-    systemdLib =
-      (libUtils {
-        inherit lib config pkgs;
-      }).systemdUtils.lib;
+    systemdUtils = (libUtils { inherit lib config pkgs; }).systemdUtils;
     isUserSystemd = false;
     podmanPackage = config.virtualisation.podman.package;
   };

--- a/pod.nix
+++ b/pod.nix
@@ -175,12 +175,12 @@ in
     };
 
     unitConfig = mkOption {
-      type = types.attrs;
+      type = types.attrsOf quadletUtils.unitOption;
       default = { };
     };
 
     serviceConfig = mkOption {
-      type = types.attrs;
+      type = types.attrsOf quadletUtils.unitOption;
       default = { };
     };
 

--- a/utils.nix
+++ b/utils.nix
@@ -1,4 +1,4 @@
-{ lib, systemdLib, isUserSystemd, podmanPackage }:
+{ lib, systemdUtils, isUserSystemd, podmanPackage }:
 
 let
   attrsToList =
@@ -25,8 +25,10 @@ in
   unitConfigToText =
     unitConfig:
     builtins.concatStringsSep "\n\n" (
-      lib.mapAttrsToList (name: section: "[${name}]\n${systemdLib.attrsToSection section}") unitConfig
+      lib.mapAttrsToList (name: section: "[${name}]\n${systemdUtils.lib.attrsToSection section}") unitConfig
     );
+
+  inherit (systemdUtils.unitOptions) unitOption;
 
   # systemd recommends multi-user.target over default.target.
   # https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#default.target


### PR DESCRIPTION
This PR changes `serviceConfig` and `unitConfig` types from `attrs` to `attrsOf unitOption`. `unitOption` comes from [NixOS' systemd-utils](https://github.com/NixOS/nixpkgs/blob/c97ad4346b9f1e2b0a4b68fc72252ed1e1597cd2/nixos/lib/systemd-unit-options.nix#L42-L51). Now the type definition [matches](https://github.com/NixOS/nixpkgs/blob/c97ad4346b9f1e2b0a4b68fc72252ed1e1597cd2/nixos/lib/systemd-unit-options.nix#L250) NixOS'.

The main benefit is that now lists inside `serviceConfig` and `unitConfig` (such as `After` or `Requires`) are merged correctly instead of being overwritten.

I have a small reproducible example to help understand the difference:

<details>

  <summary>example.nix</summary>

```nix
let
  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.11";
  pkgs = import nixpkgs { config = { system = "x86_64-linux"; }; overlays = [ ]; };

  condition = true;

  module = { libUtils, lib, ... }: {
    options = {
      justAttrs = lib.mkOption {
        type = lib.types.attrs;
        default = { };
      };

      attrsOfUnit = lib.mkOption {
        type = lib.types.attrsOf libUtils.systemdUtils.unitOptions.unitOption;
        default = { };
      };
    };

    config = lib.mkMerge [
      {
        justAttrs = {
          After = [ "multi-user.target" ];
          Requires = [ "network-online.target" ];
        };

        attrsOfUnit = {
          After = [ "multi-user.target" ];
          Requires = [ "network-online.target" ];
        };
      }
      (lib.mkIf condition {
        justAttrs = {
          After = [ "postgres.service" "redis.service" ];
          Requires = [ "traefik.service" ];
        };

        attrsOfUnit = {
          After = [ "postgres.service" "redis.service" ];
          Requires = [ "traefik.service" ];
        };
      })
    ];
  };

  result =
    pkgs.lib.evalModules {
      modules = [
        ({ config, lib, pkgs, ... }: { _module.args.libUtils = import "${nixpkgs}/nixos/lib/utils.nix" { inherit config lib pkgs; }; })
        module
      ];
    };
in
result.config

```

</details>

<details>

<summary>Execution result</summary>

```shell
> nix-instantiate --eval example.nix --strict --json | jq
```

```json
{
  "attrsOfUnit": {
    "After": [
      "multi-user.target",
      "postgres.service",
      "redis.service"
    ],
    "Requires": [
      "network-online.target",
      "traefik.service"
    ]
  },
  "justAttrs": {
    "After": [
      "postgres.service",
      "redis.service"
    ],
    "Requires": [
      "traefik.service"
    ]
  }
}

```

</details>

As you can see in `justAttrs` the fields are getting overwritten by a later definition, rather than merged.