### PR TITLE
feat: Adds UIDMap and GIDMap to containerConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See [`container.nix`](./container.nix), [`network.nix`](./network.nix), and [`po
         quadlet-nix.inputs.nixpkgs.follows = "nixpkgs";
     };
     outputs = { nixpkgs, quadlet-nix, home-manager, ... }@attrs: {
-        nixosConfigurations.machine = nixpksg.lib.nixosSystem {
+        nixosConfigurations.machine = nixpkgs.lib.nixosSystem {
             system = "x86_64-linux";
             modules = [
                 ./configuration.nix

--- a/container.nix
+++ b/container.nix
@@ -142,6 +142,14 @@ let
       description = "--user UID:...";
       property = "Group";
     };
+    
+    gidMap = quadletUtils.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "0:10000:10";
+      description = "--gidmap";
+      property = "GIDMap";
+    };
 
     healthCmd = quadletUtils.mkOption {
       type = types.nullOr types.str;

--- a/container.nix
+++ b/container.nix
@@ -143,10 +143,10 @@ let
       property = "Group";
     };
     
-    gidMap = quadletUtils.mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "0:10000:10";
+    gidMaps = quadletUtils.mkOption {
+      type = types.listOf types.str;
+      default = [  ];
+      example = [ "0:10000:10" ];
       description = "--gidmap";
       property = "GIDMap";
     };
@@ -457,10 +457,10 @@ let
       property = "Tmpfs";
     };
 
-    uidMap = quadletUtils.mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "0:10000:10";
+    uidMaps = quadletUtils.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "0:10000:10" ];
       description = "--uidmap";
       property = "UIDMap";
     };

--- a/container.nix
+++ b/container.nix
@@ -457,6 +457,14 @@ let
       property = "Tmpfs";
     };
 
+    uidMap = quadletUtils.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "0:10000:10";
+      description = "--uidmap";
+      property = "UIDMap";
+    };
+
     user = quadletUtils.mkOption {
       type = types.nullOr types.str;
       default = null;


### PR DESCRIPTION
## Adds UIDMap and GIDMap options to map ownership of the host user to the container user.
Although most situations are already covered by userNS and its many modes. There are situations where userNS doesnt cut it and can cause ownership/permission issues with volumes and mounts. This is especially prevalent in containers that use things like s6-overay which arent built to run under a rootless user. The process looses permissions if its set to anything else than UID/GID=0 which renders the container useless.

PS: also this merge request fixes a tiny typo in the flake.nix rootless example.