### PR TITLE
feat: Make container image optional

### DIFF
--- a/container.nix
+++ b/container.nix
@@ -312,7 +312,8 @@ let
     };
 
     image = quadletUtils.mkOption {
-      type = types.nonEmptyStr;
+      type = types.nullOr types.str;
+      default = null;
       example = "docker.io/library/nginx:latest";
       description = "Image specification";
       property = "Image";


### PR DESCRIPTION
This allows using options such as `rootfs` without having to provide an image.