### PR TITLE
fix: whitespace escaping

### DIFF
--- a/tests/escaping.nix
+++ b/tests/escaping.nix
@@ -12,9 +12,10 @@
           environments = {
             FOO = "aaa bbb $ccc \"ddd\n\n ";
             bar = "\"aaa\"";
+            ONLY_SPACES = "aaa bbb";
           };
           # quoted_escaped_singleline
-          exec = "-c 'echo -n \"$FOO\" > /tmp/foo.txt; echo -n \"$bar\" > /tmp/bar.txt'";
+          exec = "-c 'echo -n \"$FOO\" > /tmp/foo.txt; echo -n \"$bar\" > /tmp/bar.txt; echo -n \"$ONLY_SPACES\" > /tmp/only_spaces.txt'";
           volumes = [
             "/tmp:/tmp"
           ];
@@ -57,6 +58,9 @@
 
     machine.wait_for_file("/tmp/baz.txt", timeout=10)
     assert machine.succeed("cat /tmp/baz.txt") == 'ccc bbb aaa\n'
+
+    machine.wait_for_file("/tmp/only_spaces.txt", timeout=10)
+    assert machine.succeed("cat /tmp/only_spaces.txt") == 'aaa bbb'
   '';
 
 }

--- a/utils.nix
+++ b/utils.nix
@@ -29,7 +29,7 @@ let
     in
       if encoding == null then
         raw
-      else if (builtins.match ".*[\t\n\r].*" raw) != null then
+      else if (builtins.match ".*[:space:].*" raw) != null then
         encoded
       else if "\"${raw}\"" == encoded then
         raw


### PR DESCRIPTION
With regex `\t\n\r` the escape wasn't triggered for a simple whitespace. For example value like `FOO = "./script.sh param"` wasn't escaped.
According to https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions#Character_classes `[:space:]` is similar to `[ \t\n\r\f\v]`, so it should include existing regex + whitespace + some more. 

I ran the tests locally and they passed. 
Let me know what you think.