### PR TITLE
fix: relax escape warning

### DIFF
--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -97,7 +97,7 @@ in
       warnings =
         quadletUtils.assertionsToWarnings [
           {
-            assertion = !(builtins.any (p: p._autoEscapeRequired) allObjects);
+            assertion = cfg.autoEscape || !(builtins.any (p: p._autoEscapeRequired) allObjects);
             message = ''
               `virtualisation.quadlet.autoEscape = true` is required because this configuration contains characters that require quoting or escaping.
 

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -91,7 +91,7 @@ in
       warnings =
         quadletUtils.assertionsToWarnings [
           {
-            assertion = !(builtins.any (p: p._autoEscapeRequired) allObjects);
+            assertion = cfg.autoEscape || !(builtins.any (p: p._autoEscapeRequired) allObjects);
             message = ''
               `virtualisation.quadlet.autoEscape = true` is required because this configuration contains characters that require quoting or escaping.
 


### PR DESCRIPTION
There's no need to show the escape warning if `autoEscape` has been enabled.