### PR TITLE
feat: non-flakes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ See [`build.nix`](./build.nix), [`container.nix`](./container.nix), [`network.ni
     inputs = {
         nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
         quadlet-nix.url = "github:SEIAROTg/quadlet-nix";
-        quadlet-nix.inputs.nixpkgs.follows = "nixpkgs";
     };
     outputs = { nixpkgs, quadlet-nix, ... }@attrs: {
         nixosConfigurations.machine = nixpkgs.lib.nixosSystem {
@@ -77,7 +76,6 @@ See [`build.nix`](./build.nix), [`container.nix`](./container.nix), [`network.ni
         home-manager.url = "github:nix-community/home-manager";
         home-manager.inputs.nixpkgs.follows = "nixpkgs";
         quadlet-nix.url = "github:SEIAROTg/quadlet-nix";
-        quadlet-nix.inputs.nixpkgs.follows = "nixpkgs";
     };
     outputs = { nixpkgs, quadlet-nix, home-manager, ... }@attrs: {
         nixosConfigurations.machine = nixpkgs.lib.nixosSystem {

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,10 @@
 {
   description = "NixOS and home-manager module for Podman Quadlets";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  };
-
-  outputs =
-    { nixpkgs, ... }:
-    let
-      libUtils = import "${nixpkgs}/nixos/lib/utils.nix";
-    in
+  outputs = 
+    { self }:
     {
-      nixosModules.quadlet = import ./nixos-module.nix { inherit libUtils; };
-      homeManagerModules.quadlet = import ./home-manager-module.nix { inherit libUtils; };
+      nixosModules.quadlet = ./nixos-module.nix;
+      homeManagerModules.quadlet = ./home-manager-module.nix;
     };
 }

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -1,4 +1,3 @@
-{ libUtils }:
 {
   config,
   osConfig ? { },
@@ -12,7 +11,7 @@ let
   cfg = config.virtualisation.quadlet;
   quadletUtils = import ./utils.nix {
     inherit lib;
-    systemdUtils = (libUtils { inherit lib config pkgs; }).systemdUtils;
+    inherit (import "${pkgs.path}/nixos/lib/utils.nix" { inherit lib config pkgs; }) systemdUtils;
     podmanPackage = osConfig.virtualisation.podman.package or pkgs.podman;
     autoEscape = config.virtualisation.quadlet.autoEscape;
   };

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,4 +1,3 @@
-{ libUtils }:
 {
   config,
   lib,
@@ -11,7 +10,7 @@ let
   cfg = config.virtualisation.quadlet;
   quadletUtils = import ./utils.nix {
     inherit lib;
-    systemdUtils = (libUtils { inherit lib config pkgs; }).systemdUtils;
+    inherit (import "${pkgs.path}/nixos/lib/utils.nix" { inherit lib config pkgs; }) systemdUtils;
     podmanPackage = config.virtualisation.podman.package;
     autoEscape = config.virtualisation.quadlet.autoEscape;
   };

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -8,7 +8,6 @@
     nixpkgs.url = "path:/dev/null";
 
     quadlet-nix.url = "path:/dev/null";
-    quadlet-nix.inputs.nixpkgs.follows = "nixpkgs";
 
     home-manager.url = "path:/dev/null";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Despite efforts from the Nix devs to stabilize flakes, they are still an experimental feature.

This PR allows non-flake users to import and use this module (without using flake-compat).

As a positive side-effect, the project bundle size got reduced.

I ran the test command in tests/README.md and it completed successfully.

