### PR TITLE
Add descriptions to all options

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -220,23 +220,29 @@ in
     unitConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     serviceConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     rawConfig = mkOption {
       type = types.nullOr types.str;
       default = null;
+      description = "test";
     };
 
     _serviceName = mkOption { internal = true; };
     _configText = mkOption { internal = true; };
     _autoStart = mkOption { internal = true; };
     _autoEscapeRequired = mkOption { internal = true; };
-    ref = mkOption { readOnly = true; };
+    ref = mkOption {
+      readOnly = true;
+      description = "test";
+    };
   };
 
   config =
@@ -256,9 +262,8 @@ in
     in
     {
       _serviceName = "${name}-build";
-      _configText = if config.rawConfig != null
-        then config.rawConfig
-        else quadletUtils.unitConfigToText unitConfig;
+      _configText =
+        if config.rawConfig != null then config.rawConfig else quadletUtils.unitConfigToText unitConfig;
       _autoStart = config.autoStart;
       _autoEscapeRequired = quadletUtils.autoEscapeRequired buildConfig buildOpts;
       ref = "${name}.build";

--- a/container.nix
+++ b/container.nix
@@ -21,7 +21,7 @@ let
     addHosts = quadletUtils.mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = ["hostname:192.168.10.11"];
+      example = [ "hostname:192.168.10.11" ];
       description = "--add-host";
       property = "AddHost";
     };
@@ -150,7 +150,12 @@ let
     };
 
     exec = quadletUtils.mkOption {
-      type = types.nullOr (types.oneOf [ types.str (types.listOf types.str) ]);
+      type = types.nullOr (
+        types.oneOf [
+          types.str
+          (types.listOf types.str)
+        ]
+      );
       default = null;
       example = "/usr/bin/command";
       description = "Command after image specification";
@@ -169,7 +174,7 @@ let
 
     gidMaps = quadletUtils.mkOption {
       type = types.listOf types.str;
-      default = [  ];
+      default = [ ];
       example = [ "0:10000:10" ];
       description = "--gidmap";
       property = "GIDMap";
@@ -178,7 +183,7 @@ let
 
     globalArgs = quadletUtils.mkOption {
       type = types.listOf types.str;
-      default = [  ];
+      default = [ ];
       example = [ "--log-level=debug" ];
       description = "global args";
       property = "GlobalArgs";
@@ -413,7 +418,12 @@ let
     };
 
     notify = quadletUtils.mkOption {
-      type = types.enum [ null true false "healthy" ];
+      type = types.enum [
+        null
+        true
+        false
+        "healthy"
+      ];
       default = null;
       description = "--sdnotify container";
       property = "Notify";
@@ -697,23 +707,29 @@ in
     unitConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     serviceConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     rawConfig = mkOption {
       type = types.nullOr types.str;
       default = null;
+      description = "test";
     };
 
     _serviceName = mkOption { internal = true; };
     _configText = mkOption { internal = true; };
     _autoStart = mkOption { internal = true; };
     _autoEscapeRequired = mkOption { internal = true; };
-    ref = mkOption { readOnly = true; };
+    ref = mkOption {
+      readOnly = true;
+      description = "test";
+    };
   };
 
   config =
@@ -733,9 +749,8 @@ in
     in
     {
       _serviceName = name;
-      _configText = if config.rawConfig != null
-        then config.rawConfig
-        else quadletUtils.unitConfigToText unitConfig;
+      _configText =
+        if config.rawConfig != null then config.rawConfig else quadletUtils.unitConfigToText unitConfig;
       _autoStart = config.autoStart;
       _autoEscapeRequired = quadletUtils.autoEscapeRequired containerConfig containerOpts;
       ref = "${name}.container";

--- a/network.nix
+++ b/network.nix
@@ -58,7 +58,7 @@ let
 
     globalArgs = quadletUtils.mkOption {
       type = types.listOf types.str;
-      default = [  ];
+      default = [ ];
       example = [ "--log-level=debug" ];
       description = "global args";
       property = "GlobalArgs";
@@ -161,29 +161,34 @@ in
     unitConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     serviceConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     rawConfig = mkOption {
       type = types.nullOr types.str;
       default = null;
+      description = "test";
     };
 
     _serviceName = mkOption { internal = true; };
     _configText = mkOption { internal = true; };
     _autoStart = mkOption { internal = true; };
     _autoEscapeRequired = mkOption { internal = true; };
-    ref = mkOption { readOnly = true; };
+    ref = mkOption {
+      readOnly = true;
+      description = "test";
+    };
   };
 
   config =
     let
-      networkName =
-        if config.networkConfig.name != null then config.networkConfig.name else name;
+      networkName = if config.networkConfig.name != null then config.networkConfig.name else name;
       networkConfig = config.networkConfig // {
         name = networkName;
       };
@@ -200,9 +205,8 @@ in
     in
     {
       _serviceName = "${name}-network";
-      _configText = if config.rawConfig != null
-        then config.rawConfig
-        else quadletUtils.unitConfigToText unitConfig;
+      _configText =
+        if config.rawConfig != null then config.rawConfig else quadletUtils.unitConfigToText unitConfig;
       _autoStart = config.autoStart;
       _autoEscapeRequired = quadletUtils.autoEscapeRequired networkConfig networkOpts;
       ref = "${name}.network";

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -5,7 +5,15 @@
   ...
 }:
 let
-  inherit (lib) types lists strings mkOption attrNames attrValues mergeAttrsList;
+  inherit (lib)
+    types
+    lists
+    strings
+    mkOption
+    attrNames
+    attrValues
+    mergeAttrsList
+    ;
 
   cfg = config.virtualisation.quadlet;
   quadletUtils = import ./utils.nix {
@@ -27,26 +35,31 @@ in
       builds = mkOption {
         type = types.attrsOf buildOpts;
         default = { };
+        description = "test";
       };
 
       containers = mkOption {
         type = types.attrsOf containerOpts;
         default = { };
+        description = "test";
       };
 
       networks = mkOption {
         type = types.attrsOf networkOpts;
         default = { };
+        description = "test";
       };
 
       pods = mkOption {
         type = types.attrsOf podOpts;
         default = { };
+        description = "test";
       };
 
       volumes = mkOption {
         type = types.attrsOf volumeOpts;
         default = { };
+        description = "test";
       };
 
       autoEscape = mkOption {
@@ -63,13 +76,15 @@ in
 
   config =
     let
-      allObjects = builtins.concatLists (map attrValues [
-        cfg.builds
-        cfg.containers
-        cfg.networks
-        cfg.pods
-        cfg.volumes
-      ]);
+      allObjects = builtins.concatLists (
+        map attrValues [
+          cfg.builds
+          cfg.containers
+          cfg.networks
+          cfg.pods
+          cfg.volumes
+        ]
+      );
     in
     {
       virtualisation.podman.enable = true;
@@ -87,24 +102,24 @@ in
             '';
           }
         ];
-      warnings =
-        quadletUtils.assertionsToWarnings [
-          {
-            assertion = !(builtins.any (p: p._autoEscapeRequired) allObjects);
-            message = ''
-              `virtualisation.quadlet.autoEscape = true` is required because this configuration contains characters that require quoting or escaping.
+      warnings = quadletUtils.assertionsToWarnings [
+        {
+          assertion = !(builtins.any (p: p._autoEscapeRequired) allObjects);
+          message = ''
+            `virtualisation.quadlet.autoEscape = true` is required because this configuration contains characters that require quoting or escaping.
 
-              This will become a hard error in the future. If you have manual quoting or escaping in place, please undo those and enable `autoEscape`.
-            '';
-          }
-        ];
+            This will become a hard error in the future. If you have manual quoting or escaping in place, please undo those and enable `autoEscape`.
+          '';
+        }
+      ];
       environment.etc = mergeAttrsList (
         map (p: {
           "containers/systemd/${p.ref}" = {
             text = p._configText;
             mode = "0600";
           };
-        }) allObjects);
+        }) allObjects
+      );
       # The symlinks are not necessary for the services to be honored by systemd,
       # but necessary for NixOS activation process to pick them up for updates.
       systemd.packages = [
@@ -125,7 +140,7 @@ in
             };
             # systemd recommends multi-user.target over default.target.
             # https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#default.target
-            wantedBy = if p._autoStart then [ "multi-user.target" ] else [];
+            wantedBy = if p._autoStart then [ "multi-user.target" ] else [ ];
           };
         }) allObjects
       );

--- a/pod.nix
+++ b/pod.nix
@@ -68,7 +68,7 @@ let
 
     globalArgs = quadletUtils.mkOption {
       type = types.listOf types.str;
-      default = [  ];
+      default = [ ];
       example = [ "--log-level=debug" ];
       description = "global args";
       property = "GlobalArgs";
@@ -190,23 +190,29 @@ in
     unitConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     serviceConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     rawConfig = mkOption {
       type = types.nullOr types.str;
       default = null;
+      description = "test";
     };
 
     _serviceName = mkOption { internal = true; };
     _configText = mkOption { internal = true; };
     _autoStart = mkOption { internal = true; };
     _autoEscapeRequired = mkOption { internal = true; };
-    ref = mkOption { readOnly = true; };
+    ref = mkOption {
+      readOnly = true;
+      description = "test";
+    };
   };
 
   config =
@@ -230,9 +236,8 @@ in
     in
     {
       _serviceName = "${name}-pod";
-      _configText = if config.rawConfig != null
-        then config.rawConfig
-        else quadletUtils.unitConfigToText unitConfig;
+      _configText =
+        if config.rawConfig != null then config.rawConfig else quadletUtils.unitConfigToText unitConfig;
       _autoEscapeRequired = quadletUtils.autoEscapeRequired podConfig podOpts;
       _autoStart = config.autoStart;
       ref = "${name}.pod";

--- a/volume.nix
+++ b/volume.nix
@@ -42,7 +42,7 @@ let
 
     globalArgs = quadletUtils.mkOption {
       type = types.listOf types.str;
-      default = [  ];
+      default = [ ];
       example = [ "--log-level=debug" ];
       description = "global args";
       property = "GlobalArgs";
@@ -50,7 +50,12 @@ let
     };
 
     group = quadletUtils.mkOption {
-      type = types.nullOr (types.oneOf [ types.int types.str ]);
+      type = types.nullOr (
+        types.oneOf [
+          types.int
+          types.str
+        ]
+      );
       default = null;
       example = 192;
       description = "--opt group=...";
@@ -106,7 +111,12 @@ let
     };
 
     user = quadletUtils.mkOption {
-      type = types.nullOr (types.oneOf [ types.int types.str ]);
+      type = types.nullOr (
+        types.oneOf [
+          types.int
+          types.str
+        ]
+      );
       default = null;
       example = 123;
       description = "--opt uid=...";
@@ -130,23 +140,29 @@ in
     unitConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     serviceConfig = mkOption {
       type = types.attrsOf quadletUtils.unitOption;
       default = { };
+      description = "test";
     };
 
     rawConfig = mkOption {
       type = types.nullOr types.str;
       default = null;
+      description = "test";
     };
 
     _serviceName = mkOption { internal = true; };
     _configText = mkOption { internal = true; };
     _autoStart = mkOption { internal = true; };
     _autoEscapeRequired = mkOption { internal = true; };
-    ref = mkOption { readOnly = true; };
+    ref = mkOption {
+      readOnly = true;
+      description = "test";
+    };
   };
 
   config =
@@ -166,9 +182,8 @@ in
     in
     {
       _serviceName = "${name}-volume";
-      _configText = if config.rawConfig != null
-        then config.rawConfig
-        else quadletUtils.unitConfigToText unitConfig;
+      _configText =
+        if config.rawConfig != null then config.rawConfig else quadletUtils.unitConfigToText unitConfig;
       _autoStart = config.autoStart;
       _autoEscapeRequired = quadletUtils.autoEscapeRequired volumeConfig volumeOpts;
       ref = "${name}.volume";


### PR DESCRIPTION
When using quadlet-nix on `nix (Nix) 2.24.11`, I get errors that cause my build to fail like this:
```
Treating warnings as errors. Set documentation.nixos.options.warningsAreErrors to false to ignore these warnings.
error: option virtualisation.quadlet.builds has no description
error: option virtualisation.quadlet.builds.<name>.rawConfig has no description
error: option virtualisation.quadlet.builds.<name>.ref has no description
error: option virtualisation.quadlet.builds.<name>.serviceConfig has no description
error: option virtualisation.quadlet.builds.<name>.unitConfig has no description
error: option virtualisation.quadlet.containers has no description
error: option virtualisation.quadlet.containers.<name>.rawConfig has no description
error: option virtualisation.quadlet.containers.<name>.ref has no description
error: option virtualisation.quadlet.containers.<name>.serviceConfig has no description
error: option virtualisation.quadlet.containers.<name>.unitConfig has no description
error: option virtualisation.quadlet.networks has no description
error: option virtualisation.quadlet.networks.<name>.rawConfig has no description
error: option virtualisation.quadlet.networks.<name>.ref has no description
error: option virtualisation.quadlet.networks.<name>.serviceConfig has no description
error: option virtualisation.quadlet.networks.<name>.unitConfig has no description
error: option virtualisation.quadlet.pods has no description
error: option virtualisation.quadlet.pods.<name>.rawConfig has no description
error: option virtualisation.quadlet.pods.<name>.ref has no description
error: option virtualisation.quadlet.pods.<name>.serviceConfig has no description
error: option virtualisation.quadlet.pods.<name>.unitConfig has no description
error: option virtualisation.quadlet.volumes has no description
error: option virtualisation.quadlet.volumes.<name>.rawConfig has no description
error: option virtualisation.quadlet.volumes.<name>.ref has no description
error: option virtualisation.quadlet.volumes.<name>.serviceConfig has no description
error: option virtualisation.quadlet.volumes.<name>.unitConfig has no description
```

I could disable warnings as errors, but would rather not. Right now, this PR shows where to add the descriptions to get these errors to go away, but sets them to dummy values. 

How would you like me to proceed with this PR? 
- Add properly written string descriptions to each (like it is now)? Not very DRY. Changing one description in one submodule should change it in all.
- Factor out the submodule option to into a shared thing in utils?
- Something else?

I am not even sure you want a change like this, so that is why I put minimal work here and want instructions for proceeding. It might also be good if you can give what you think each of these four sub-options descriptions should be. Here is a working draft to start:
| sub-option      | description                                                                                                                                                                                                                                                                                                               |
| :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `rawConfig`     | **Raw content for the Quadlet file.** This option allows you to provide the entire INI-formatted content for the generated Quadlet file (e.g., `.pod`, `.container`). If set, this content is used directly, replacing any configuration that would otherwise be generated from the structured options for this resource. Does not override autoStart. |
| `ref`           | **A stable, generated identifier for this specific Quadlet resource.** This identifier (e.g., `my-app.pod` for a pod named `my-app`, or `web-server.container` for a container named `web-server`) can be used to refer to this resource in other parts of the NixOS configuration or in Quadlet files where such a reference is supported. |
| `serviceConfig` | **Systemd service unit options.** Allows you to configure settings for the `[Service]` section of the generated systemd service file that manages this Quadlet unit. These settings will be merged with (and can override) any default service options defined by the module (e.g., default `Restart` policy or `TimeoutStartSec`). |
| `unitConfig`    | **Systemd unit options.** Allows you to configure settings for the `[Unit]` section of the generated systemd service file that manages this Quadlet unit. These settings will be merged with (and can override) any default unit options defined by the module (e.g., a default `Description`).                             |

^ this part is ai-generated with my own edits, sorry if incorrect. I mostly understand rawConfig and ref, just not serviceConfig and unitConfig, yet.