### PR TITLE
feat: enable rootful auto-update option

### DIFF
--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (lib) types mkOption mergeAttrsList mkIf getExe;
+  inherit (lib) mergeAttrsList mkIf getExe;
 
   cfg = config.virtualisation.quadlet;
   quadletUtils = import ./utils.nix {
@@ -24,20 +24,7 @@ let
   '';
 in
 {
-  options.virtualisation.quadlet = quadletOptions.mkTopLevelOptions {
-    autoUpdate = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enables podman auto update.";
-      };
-      calendar = mkOption {
-        type = types.str;
-        default = "*-*-* 00:00:00";
-        description = "Schedule for podman auto update. See `systemd.time(7)` for details.";
-      };
-    };
-  };
+  options.virtualisation.quadlet = quadletOptions.mkTopLevelOptions { };
   config =
     let
       allObjects = quadletOptions.getAllObjects cfg;

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mergeAttrsList;
+  inherit (lib) mergeAttrsList mkIf;
 
   cfg = config.virtualisation.quadlet;
   quadletUtils = import ./utils.nix {
@@ -61,5 +61,11 @@ in
           };
         }) allObjects
       );
+
+      systemd.timers.podman-auto-update = mkIf cfg.autoUpdate.enable {
+        timerConfig.OnCalendar = [ "" cfg.autoUpdate.calendar ];
+        wantedBy = [ "timers.target" ];
+        overrideStrategy = "asDropin";
+      };
     };
 }

--- a/options.nix
+++ b/options.nix
@@ -124,6 +124,18 @@ let
         Not enabled by default to avoid breaking existing configurations. In the future this will be required.
       '';
     };
+    autoUpdate = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Enables podman auto update.";
+      };
+      calendar = lib.mkOption {
+        type = lib.types.str;
+        default = "*-*-* 00:00:00";
+        description = "Schedule for podman auto update. See `systemd.time(7)` for details.";
+      };
+    };
   };
 
   getAllObjects = config: builtins.concatLists (map lib.attrValues [


### PR DESCRIPTION
Even though podman creates the podman-auto-update systemd timer for you, it isn't enabled by default. This adds the bool option "autoUpdate" to the nixOS module, which if true enables podman-auto-update.timer. 

It does this by "overriding" podman-auto-update.timer's wantedBy with the same value it already has. Assigning wantedBy creates a symlink in timers.target.wants, enabling and starting the timer. This will break if podman renames the auto-update timer & service, so it might be more correct to re-write them entirely like the home-manager module, but personally I like the simplicity of this.