### PR TITLE
feat: adds module enable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ See [seiarotg.github.io/quadlet-nix](https://seiarotg.github.io/quadlet-nix) for
     virtualisation.quadlet = let
         inherit (config.virtualisation.quadlet) networks pods;
     in {
+        enable = true;
         containers = {
             nginx.containerConfig.image = "docker.io/library/nginx:latest";
             nginx.containerConfig.networks = [ "podman" networks.internal.ref ];
@@ -154,7 +155,6 @@ See [seiarotg.github.io/quadlet-nix](https://seiarotg.github.io/quadlet-nix) for
             modules = [
                 ./configuration.nix
                 home-manager.nixosModules.home-manager
-                # to enable podman & podman systemd generator
                 quadlet-nix.nixosModules.quadlet
             ];
         };
@@ -180,6 +180,7 @@ See [seiarotg.github.io/quadlet-nix](https://seiarotg.github.io/quadlet-nix) for
         # This is crucial to ensure the systemd services are (re)started on config change
         systemd.user.startServices = "sd-switch";
         virtualisation.quadlet.containers = {
+            enable = true;
             echo-server = {
                 autoStart = true;
                 serviceConfig = {
@@ -210,6 +211,7 @@ If you wish to write raw Quadlet files instead of using the Nix options, you may
     virtualisation.quadlet = let
         inherit (config.virtualisation.quadlet) networks pods;
     in {
+        enable = true;
         containers = {
             nginx.rawConfig = ''
                 [Container]

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -29,7 +29,7 @@ in
     let
       allObjects = quadletOptions.getAllObjects cfg;
     in
-    {
+    mkIf cfg.enable {
       assertions = quadletOptions.mkAssertions [ ] cfg;
       warnings = quadletOptions.mkWarnings [ ] cfg;
 

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -25,7 +25,7 @@ in
     let
       allObjects = quadletOptions.getAllObjects cfg;
     in
-    {
+    mkIf cfg.enable {
       assertions = quadletOptions.mkAssertions [ ] cfg;
       warnings = quadletOptions.mkWarnings [ ] cfg;
 

--- a/options.nix
+++ b/options.nix
@@ -115,6 +115,15 @@ let
       default = { };
       description = "Volumes";
     };
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Enable quadlet-nix, a NixOS module to manage Podman containers and networks via Quadlet.
+
+        Enabled by default to avoid breaking exising configurations. In the future this may be enabled by default.
+      '';
+    };
     autoEscape = lib.mkOption {
       type = lib.types.bool;
       default = false;

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -53,6 +53,7 @@
             quadlet-nix.nixosModules.quadlet
             testConfig
           ];
+          virtualisation.quadlet.enable = true;
           environment.systemPackages = [ pkgs.curl ];
           specialisation = builtins.mapAttrs (name: value: { configuration = value; }) (specialisation attrs);
         };
@@ -67,6 +68,7 @@
             quadlet-nix.nixosModules.quadlet
             home-manager.nixosModules.home-manager
           ];
+          virtualisation.quadlet.enable = true;
           environment.systemPackages = [ pkgs.curl ];
 
           # brings up network-online.target
@@ -88,6 +90,7 @@
               quadlet-nix.homeManagerModules.quadlet
               testConfig
             ];
+            virtualisation.quadlet.enable = true;
             systemd.user.startServices = "sd-switch";
             home.stateVersion = config.system.nixos.release;
           });
@@ -100,6 +103,7 @@
                   testConfig
                   value
                 ];
+                virtualisation.quadlet.enable = true;
                 systemd.user.startServices = "sd-switch";
                 home.stateVersion = config.system.nixos.release;
               });


### PR DESCRIPTION
## Rationale
I think how this module handles modifying NixOS config is fairly non-standard. Modules I'm familiar with have enable flags, as vanilla NixOS modules have. I think it's poor ergonomics to "magically" add system dependencies and configuration without explicitly enabling them.

The lack of an enable option has caused me issue in my NixOS configuration. I wanted to make a wrapper module around `quadlet-nix` which only enables quadlet (and thereby enables podman and installs necessary dependencies) if the module is explicitly enabled. However, seeing as conditional imports aren't possible, I would be stuck with the module enabling podman whenever it was loaded, which is especially problematic for project structures that use auto-loaded modules with configuration locked behind options, like [Snowfall Lib](https://github.com/snowfallorg).

## Changes
- Adds an `virtualisation.quadlet.enable` option. For backwards compatibility, **this option is true by default!** I think an `assert` warning with several months' leniency before setting its default to `false` (in line with every other `enable` option) would be prudent, but that's for the maintainer to decide.

### Side note
To maintainers: This module is great! I was rolling up my own half-baked wrapper around [arion](https://github.com/hercules-ci/arion) to add networks support, but it turns out I don't need to anymore! I think Quadlet is the perfect fit for NixOS given its declarative, systemd-driven design. There couldn't be a more perfect combination. Thank you!