### PR TITLE
Allow specifying multiple "option" values for networks

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -7,6 +7,7 @@
 }:
 let
   inherit (lib) types;
+  inherit (quadletUtils) encoders;
 
   buildOpts = {
     annotations = quadletOptions.mkOption {
@@ -15,7 +16,7 @@ let
       example = [ "XYZ" ];
       cli = "--annotation";
       property = "Annotation";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     arch = quadletOptions.mkOption {
@@ -74,7 +75,7 @@ let
       };
       cli = "--env";
       property = "Environment";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     file = quadletOptions.mkOption {
@@ -98,7 +99,7 @@ let
       example = [ "--log-level=debug" ];
       description = "Additional command line arguments to insert between `podman` and `build`";
       property = "GlobalArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     addGroups = quadletOptions.mkOption {
@@ -123,7 +124,7 @@ let
       example = [ "XYZ" ];
       cli = "--label";
       property = "Label";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     networks = quadletOptions.mkOption {
@@ -140,7 +141,7 @@ let
       example = [ "--add-host foobar" ];
       description = "Additional command line arguments to insert after `podman build`";
       property = "PodmanArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     pull = quadletOptions.mkOption {
@@ -173,7 +174,7 @@ let
       example = [ "secret[,opt=opt …]" ];
       cli = "--secret";
       property = "Secret";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     workdir = quadletOptions.mkOption {

--- a/container.nix
+++ b/container.nix
@@ -7,6 +7,7 @@
 }:
 let
   inherit (lib) types;
+  inherit (quadletUtils) encoders;
 
   containerOpts = {
     addCapabilities = quadletOptions.mkOption {
@@ -15,7 +16,7 @@ let
       example = [ "NET_ADMIN" ];
       cli = "--cap-add";
       property = "AddCapability";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     addHosts = quadletOptions.mkOption {
@@ -32,7 +33,7 @@ let
       example = [ "/dev/foo" ];
       cli = "--device";
       property = "AddDevice";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     annotations = quadletOptions.mkOption {
@@ -41,7 +42,7 @@ let
       example = [ "XYZ" ];
       cli = "--annotation";
       property = "Annotation";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     autoUpdate = quadletOptions.mkOption {
@@ -111,15 +112,17 @@ let
       example = [ "NET_ADMIN" ];
       cli = "--cap-drop";
       property = "DropCapability";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     entrypoint = quadletOptions.mkOption {
-      type = types.nullOr types.str;
+      type = types.nullOr (types.oneOf [ types.str (types.listOf types.str) ]);
       default = null;
       example = "/foo.sh";
       cli = "--entrypoint";
       property = "Entrypoint";
+      encoders.raw = encoders.scalar.raw;
+      encoders.list = encoders.list.json;
     };
 
     environments = quadletOptions.mkOption {
@@ -130,7 +133,7 @@ let
       };
       cli = "--env";
       property = "Environment";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     environmentFiles = quadletOptions.mkOption {
@@ -139,7 +142,7 @@ let
       example = [ "/tmp/env" ];
       cli = "--env-file";
       property = "EnvironmentFile";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     environmentHost = quadletOptions.mkOption {
@@ -156,7 +159,8 @@ let
       description = "Command after image specification";
       property = "Exec";
       # CAVEAT: doesn't prevent systemd environment variable substitution, but probably a quadlet problem?
-      encoding = "quoted_escaped_singleline";
+      encoders.scalar = encoders.scalar.raw;
+      encoders.list = encoders.list.oneLine encoders.scalar.quotedEscaped;
     };
 
     exposePorts = quadletOptions.mkOption {
@@ -173,7 +177,7 @@ let
       example = [ "0:10000:10" ];
       cli = "--gidmap";
       property = "GIDMap";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     globalArgs = quadletOptions.mkOption {
@@ -182,7 +186,7 @@ let
       example = [ "--log-level=debug" ];
       description = "Additional command line arguments to insert between `podman` and `run`";
       property = "GlobalArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     group = quadletOptions.mkOption {
@@ -351,7 +355,7 @@ let
       example = [ "XYZ" ];
       cli = "--label";
       property = "Label";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     logDriver = quadletOptions.mkOption {
@@ -368,7 +372,7 @@ let
       example = [ "path=/var/log/mykube.json" ];
       cli = "--log-opt";
       property = "LogOpt";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     mask = quadletOptions.mkOption {
@@ -377,7 +381,7 @@ let
       example = "/proc/sys/foo:/proc/sys/bar";
       cli = "--security-opt mask=...";
       property = "Mask";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     memory = quadletOptions.mkOption {
@@ -394,7 +398,7 @@ let
       example = [ "type=..." ];
       cli = "--mount";
       property = "Mount";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     networks = quadletOptions.mkOption {
@@ -448,7 +452,7 @@ let
       example = [ "--add-host foobar" ];
       description = "Additional command line arguments to insert after `podman run`";
       property = "PodmanArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     publishPorts = quadletOptions.mkOption {
@@ -487,7 +491,8 @@ let
       description = "Adds ExecReload and run exec with the value";
       example = "/usr/bin/command";
       property = "ReloadCmd";
-      encoding = "quoted_escaped_singleline";
+      encoders.scalar = encoders.scalar.raw;
+      encoders.list = encoders.list.oneLine encoders.scalar.quotedEscaped;
     };
 
     reloadSignal = quadletOptions.mkOption {
@@ -543,7 +548,7 @@ let
       example = [ "secret[,opt=opt …]" ];
       cli = "--secret";
       property = "Secret";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     securityLabelDisable = quadletOptions.mkOption {
@@ -639,7 +644,7 @@ let
       };
       cli = "--sysctl";
       property = "Sysctl";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     timezone = quadletOptions.mkOption {
@@ -664,7 +669,7 @@ let
       example = [ "0:10000:10" ];
       cli = "--uidmap";
       property = "UIDMap";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     ulimits = quadletOptions.mkOption {
@@ -681,7 +686,7 @@ let
       example = "ALL";
       cli = "--security-opt unmask=...";
       property = "Unmask";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     user = quadletOptions.mkOption {

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -63,10 +63,7 @@ in
             };
           }) allObjects
         ) // {
-          # TODO: remove once most people are on 25.05.
-          # the stock service uses `sh` instead of `/bin/sh`.
-          # systemd only looks for command binary in a few static location.
-          # See: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines
+          # `systemctl`, `sleep`, etc. not found
           "systemd/user/podman-user-wait-network-online.service.d/override.conf" = {
             text = quadletUtils.unitConfigToText {
               Service.ExecSearchPath = [ "/run/current-system/sw/bin/" ];

--- a/network.nix
+++ b/network.nix
@@ -7,6 +7,7 @@
 }:
 let
   inherit (lib) types getExe;
+  inherit (quadletUtils) encoders;
 
   networkOpts = {
     modules = quadletOptions.mkOption {
@@ -60,7 +61,7 @@ let
       example = [ "--log-level=debug" ];
       description = "Additional command line arguments to insert between `podman` and `network create`";
       property = "GlobalArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     internal = quadletOptions.mkOption {
@@ -105,7 +106,7 @@ let
       example = [ "XYZ" ];
       cli = "--label";
       property = "Label";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     name = quadletOptions.mkOption {
@@ -129,7 +130,7 @@ let
       example = [ "isolate=true" ];
       cli = "--opt";
       property = "Options";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     podmanArgs = quadletOptions.mkOption {
@@ -138,7 +139,7 @@ let
       example = [ "--dns=192.168.55.1" ];
       description = "Additional command line arguments to insert after `podman network create`";
       property = "PodmanArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     subnets = quadletOptions.mkOption {

--- a/network.nix
+++ b/network.nix
@@ -124,9 +124,9 @@ let
     };
 
     options = quadletOptions.mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "isolate";
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "isolate" ];
       cli = "--opt";
       property = "Options";
       encoding = "quoted_escaped";

--- a/network.nix
+++ b/network.nix
@@ -126,7 +126,7 @@ let
     options = quadletOptions.mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = [ "isolate" ];
+      example = [ "isolate=true" ];
       cli = "--opt";
       property = "Options";
       encoding = "quoted_escaped";

--- a/pod.nix
+++ b/pod.nix
@@ -7,6 +7,7 @@
 }:
 let
   inherit (lib) types;
+  inherit (quadletUtils) encoders;
 
   podOpts = {
     name = quadletOptions.mkOption {
@@ -63,7 +64,7 @@ let
       example = [ "0:10000:10" ];
       cli = "--gidmap";
       property = "GIDMap";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     globalArgs = quadletOptions.mkOption {
@@ -72,7 +73,7 @@ let
       example = [ "--log-level=debug" ];
       description = "Additional command line arguments to insert between `podman` and `pod create`";
       property = "GlobalArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     hostname = quadletOptions.mkOption {
@@ -105,7 +106,7 @@ let
       example = [ "XYZ" ];
       cli = "--label";
       property = "Label";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     networks = quadletOptions.mkOption {
@@ -130,7 +131,7 @@ let
       example = [ "--cpus=2" ];
       description = "Additional command line arguments to insert after `podman pod create`";
       property = "PodmanArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     publishPorts = quadletOptions.mkOption {
@@ -173,7 +174,7 @@ let
       example = [ "0:10000:10" ];
       cli = "--uidmap";
       property = "UIDMap";
-      encoding = "quoted_unescaped";
+      encoders.scalar = encoders.scalar.quotedUnescaped;
     };
 
     userns = quadletOptions.mkOption {

--- a/utils.nix
+++ b/utils.nix
@@ -3,55 +3,74 @@
 let
   # encodes value based on how podman parses them
   # see: https://github.com/containers/podman/blob/main/pkg/systemd/quadlet/quadlet.go
-  encodeValue = encoding: value:
-    # Lookup, LookupAll, LookupLast, LookupAllRaw, LookupLastRaw
-    if encoding == null then
-      systemdUtils.lib.toOption value
-    # LookupAllArgs, LookupAllKeyVal
-    else if encoding == "quoted_escaped" then
-      lib.strings.toJSON value  # same as systemdUtils.lib.serviceToUnit
-    # LookupAllStrv
-    else if encoding == "quoted_unescaped" then
-      "\"${value}\""
-    # LookupLastArgs
-    else if encoding == "quoted_escaped_singleline" then
-      if builtins.isString value then
-        value
-      else
-        builtins.concatStringsSep " " (map (lib.strings.toJSON) value)
-    else
-      throw "quadlet-nix internal error: unknown encoding ${encoding}";
-
-  encodeValueIfNeeded = encoding: value:
-    let
-      raw = encodeValue null value;
-      encoded = encodeValue encoding value;
+  encoders = let
+    # wraps a scalar encoder so it tries not escaping if possible
+    makePassive = f: x: let
+      raw = systemdUtils.lib.toOption x;
+      encoded = f x;
+      canSkip = encoded == raw || (builtins.match ".*[ \t\n\r].*" raw == null && "\"${raw}\"" == encoded);
     in
-      if encoding == null then
-        raw
-      # https://github.com/systemd/systemd/blob/f0d76134661e62622c6030cb4d05d4669b41e25a/src/basic/string-util.h#L14
-      else if (builtins.match ".*[ \t\n\r].*" raw) != null then
-        encoded
-      else if "\"${raw}\"" == encoded then
-        raw
-      else
-        encoded;
+      if canSkip then raw else encoded;
 
-  encodeValuesIfNeeded = encoding: values:
-    if builtins.isAttrs values then
-      lib.mapAttrsToList (name: value: encodeValueIfNeeded encoding "${name}=${value}") values
-    else if builtins.isList values && encoding != "quoted_escaped_singleline" then
-      map (encodeValueIfNeeded encoding) values
+  in {
+    scalar.legacy = systemdUtils.lib.toOption;
+
+    # Lookup, LookupAll, LookupLast, LookupAllRaw, LookupLastRaw
+    scalar.raw = x:
+      let ret = systemdUtils.lib.toOption x;
+    in
+      if builtins.match ".*[\r\n].*" ret == null then ret
+      else throw "quadlet-nix internal error: unsafe value for scalar.raw option: ${ret}";
+
+    # LookupAllArgs, LookupAllKeyVal
+    # same as systemdUtils.lib.serviceToUnit
+    scalar.quotedEscaped = makePassive builtins.toJSON;
+
+    # LookupAllStrv
+    scalar.quotedUnescaped = makePassive (x:
+      let
+        escaped = builtins.toJSON x;
+        unescaped = "\"${systemdUtils.lib.toOption x}\"";
+      in
+        if escaped == unescaped then unescaped
+        else throw "quadlet-nix internal error: unsafe value for scalar.quotedUnescaped option: ${escaped}"
+    );
+
+    list.default = fScalar: x: map fScalar x;
+
+    # LookupLastArgs
+    list.oneLine = fScalar: x: builtins.concatStringsSep " " (map fScalar x);
+
+    list.json = builtins.toJSON;
+
+    attrs.default = fScalar: x: lib.mapAttrsToList (k: v: "${k}=${fScalar v}") x;
+  };
+
+  encode = encoders: value:
+    if builtins.isString value || builtins.isInt value || builtins.isBool value then
+      encoders.scalar value
+    else if builtins.isList value then
+      encoders.list value
+    else if builtins.isAttrs value then
+      encoders.attrs value
     else
-      encodeValueIfNeeded encoding values;
+      throw "quadlet-nix internal error: unexpected type for encoder";
+
+  finalizeEncoders = autoEscape: optionEncoders:
+    let
+      effEncoders = if autoEscape then optionEncoders else { scalar = encoders.scalar.legacy; };
+      scalar = effEncoders.scalar or encoders.scalar.raw;
+      list = effEncoders.list or (encoders.list.default scalar);
+      attrs = effEncoders.attrs or (encoders.attrs.default scalar);
+    in
+      { inherit scalar list attrs; };
 
   configToProperties = autoEscape: config: options:
     let
       nonNullConfig = lib.filterAttrs (_: value: value != null) config;
-      encode = if autoEscape then encodeValuesIfNeeded else _: encodeValuesIfNeeded null;
       encodeEntry = name: value:
         lib.nameValuePair options.${name}.property
-        (encode options.${name}.encoding value);
+        (encode (finalizeEncoders autoEscape options.${name}.encoders) value);
     in lib.mapAttrs' encodeEntry nonNullConfig;
 
 in
@@ -69,5 +88,5 @@ in
     map (x: x.message) (builtins.filter (x: !x.assertion) asssertions);
 
   inherit (systemdUtils.unitOptions) unitOption;
-  inherit podmanPackage;
+  inherit podmanPackage encoders;
 }

--- a/volume.nix
+++ b/volume.nix
@@ -7,6 +7,7 @@
 }:
 let
   inherit (lib) types;
+  inherit (quadletUtils) encoders;
 
   volumeOpts = {
     name = quadletOptions.mkOption {
@@ -46,7 +47,7 @@ let
       example = [ "--log-level=debug" ];
       description = "Additional command line arguments to insert between `podman` and `volume create`";
       property = "GlobalArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     group = quadletOptions.mkOption {
@@ -71,7 +72,7 @@ let
       example = [ "foo=bar" ];
       cli = "--label";
       property = "Label";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     modules = quadletOptions.mkOption {
@@ -95,7 +96,7 @@ let
       example = [ "--driver=image" ];
       description = "Additional command line arguments to insert after `podman volume create`";
       property = "PodmanArgs";
-      encoding = "quoted_escaped";
+      encoders.scalar = encoders.scalar.quotedEscaped;
     };
 
     type = quadletOptions.mkOption {


### PR DESCRIPTION
Networks allow/require repeated specification of option fields to specify multiple network options. This changes the type and allows for multiple specified options

References:
- The upstream `Options` [docs](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#options) don't really give a ton of guidance, probably why this was missed
- Multiple options specified in an [E2E Test](https://github.com/containers/podman/blob/c8272b23a59846c92a2a2967263a94d5fb5a784e/test/e2e/quadlet/options.multiple.network#L6-L7)

Other notes:
- I found this while experimenting, but am not currently using it for my setup. So field testing here isn't super great so far
- This probably breaks some existing configs, but not sure what the roll-off for type changes in an option are