### PR TITLE
feat: allows custom autoStart targets

### DIFF
--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -88,7 +88,13 @@ in
             # sd-switch only starts new services with those symlinks.
             ${p._serviceName} = {
               Unit.X-QuadletNixConfigHash = builtins.hashString "sha256" p._configText;
-              Install.WantedBy = if p._autoStart then [ "default.target" ] else [ ];
+              Install.WantedBy =
+                if builtins.isString p._autoStart then
+                  [ p._autoStart ]
+                else if p._autoStart then
+                  [ "default.target" ]
+                else
+                  [ ];
             };
           }) allObjects
         )

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -60,7 +60,13 @@ in
             unitConfig.X-QuadletNixConfigHash = builtins.hashString "sha256" p._configText;
             # systemd recommends multi-user.target over default.target.
             # https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#default.target
-            wantedBy = if p._autoStart then [ "multi-user.target" ] else [ ];
+            wantedBy =
+              if builtins.isString p._autoStart then
+                [ p._autoStart ]
+              else if p._autoStart then
+                [ "multi-user.target" ]
+              else
+                [ ];
           }
           // p._overrides;
         }) allObjects

--- a/options.nix
+++ b/options.nix
@@ -36,7 +36,7 @@ let
     defaultDependencies = mkOption {
       type = lib.types.nullOr lib.types.bool;
       default = null;
-      description = "Add Quadlet’s default network dependencies to the unit";
+      description = "Add Quadlet's default network dependencies to the unit";
       property = "DefaultDependencies";
     };
   };
@@ -47,9 +47,9 @@ let
       quadletConfig = quadletOpts;
 
       autoStart = lib.mkOption {
-        type = lib.types.bool;
+        type = lib.types.either lib.types.bool lib.types.str;
         default = true;
-        description = "When enabled, this ${objectType} is automatically started on boot.";
+        description = "When enabled, this ${objectType} is automatically started on boot. Set to a string to use a custom systemd target.";
       };
 
       unitConfig = lib.mkOption {


### PR DESCRIPTION
A small convenience change to allow specifying custom autoStart targets. The idea behind this is to create a systemd timer such as:

```nix
  systemd.timers.podman-delayed-boot = {
    Unit.Description = "Podman delayed boot target";
    Timer.OnBootSec = 0;
    Install.WantedBy = [ "timers.target" ];
  };
```

... and then attach the container startup to `podman-delayed-boot.timer`, so that the critical boot path is not blocked on systems with many containers.

This could currently be achieved by manually setting `autoStart = false`, and `unitConfig.WantedBy = "podman-delayed-boot.timer"`, but I think that's a bit too verbose.